### PR TITLE
Corrected the markdown for tester program output in Workshop 05 readme.md

### DIFF
--- a/WS05/readme.md
+++ b/WS05/readme.md
@@ -352,8 +352,11 @@ int emptyApartments(const Apartment* apt, int num) {
    }
    return sum;
 }
+```
+
 ## Execution sample
 The tester program tests all the operator overloads and the output should be as follows:
+
 ```Text
 Using bool conversion overload and operator ~ to print the apartments
 +-----+------+--------------+


### PR DESCRIPTION
The output of the tester program was a bit off because it was missing correct markdown format