### PR TITLE
WS03: Input correct parameters for expYear and expMonth

### DIFF
--- a/WS03/lab/main.cpp
+++ b/WS03/lab/main.cpp
@@ -23,7 +23,7 @@ void listCCs();
 int main() {
    CC cc;
    cc.set();
-   cc.set("Hubert Blaine", 4098765423457896, 100);
+   cc.set("Hubert Blaine", 4098765423457896, 100,12,24);
    cout << "Valid credit card record: " << endl;
    cc.display();
    cout << "+-----+--------------------------------+---------------------+-----+-------+" << endl;


### PR DESCRIPTION
When set is called with the values (“Hubert Blaine”, 4098765423457896, 100), it returns “Invalid Credit Card Record” because the validation fails. This does not match the expected output in [correct_output.txt].

To fix this, include the missing expYear and expMonth when calling the function.

My details:
Jaishnav Prasad <jprasad3@myseneca.ca>
Section: NDD