### PR TITLE
Mistake in main.cpp file: fixing the parameter exp_year and expmonth …

### DIFF
--- a/WS03/lab/main.cpp
+++ b/WS03/lab/main.cpp
@@ -23,7 +23,7 @@ void listCCs();
 int main() {
    CC cc;
    cc.set();
-   cc.set("Hubert Blaine", 4098765423457896, 100);
+   cc.set("Hubert Blaine", 4098765423457896, 100,12,24);
    cout << "Valid credit card record: " << endl;
    cc.display();
    cout << "+-----+--------------------------------+---------------------+-----+-------+" << endl;


### PR DESCRIPTION
There is a typo in the main file where the parameter of the  second  set function call in the workshop 03.. I have added the extra 2 parameters in the main.cpp file.